### PR TITLE
feat(client): add WebSocket exec and log sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **`pkg/apps`:** default deploy YAML `apiVersion` is `iofog.org/v3`. Datasance-flavored callers use `apps.WithAPIVersion("datasance.com/v3")`.
 - **`pkg/apps` deploy types:** canonical image keys `amd64`, `arm64`, `riscv64`, `arm` (removed `x86`/`arm`); `flow` → `application`; `dockerUrl` → `containerEngineUrl`.
 - **`pkg/client` — Controller REST v3.8:** `fogTypeId`/`FogType`/`agentType` → `archId`/`ArchID`/`arch`; flow APIs removed in favor of application name; auth endpoint updates (`POST /users`, `POST /user/change-password`); `RefreshUserSubscriptionKey` removed.
+- **`pkg/client` — microservice exec:** removed `AttachExecMicroservice`, `DetachExecMicroservice`, `AttachExecSystemMicroservice`, and `DetachExecSystemMicroservice`. Use WebSocket dial instead of REST enable/disable before exec.
 
 ### Added
 
@@ -24,16 +25,20 @@
 - GitHub Actions CI (`.github/workflows/ci.yml`): `make lint`, `make security-code`, `make vulncheck`.
 - `SECURITY.md` maintainer security gates and documented gosec exceptions.
 - `NOTICE` Eclipse ioFog attribution; per-file Datasance copyright headers removed from `pkg/**`.
+- **`pkg/client` — exec sessions:** `DialMicroserviceExec`, `DialSystemMicroserviceExec`, `ExecSession` IO (`Read`, `WriteStdin`, `WriteControl`, `Close`), `DialExecOptions` (`WaitForAgentReady`, `OnStatusLine`), and exec WebSocket error constants. Fog debug provision unchanged (`AttachExecToAgent` / `DetachExecFromAgent`).
+- **`pkg/client` — log streaming:** `DialMicroserviceLogs`, `DialSystemMicroserviceLogs`, `DialFogLogs`, `LogSession` (`Read`, `Close`), `LogTailOptions` (`tail`, `follow`, `since`, `until`), and log WebSocket error constants (`ErrLogSessionUnavailable`, `ErrLogAuthenticationFailed`, `ErrAgentNotRunning`, etc.).
 
 ### Changed
 
 - Copyright attribution consolidated in `NOTICE`.
 - golangci-lint v2 config; gosec runs via `make security-code` (not inside golangci-lint).
+- **`pkg/client` — WebSocket sessions:** `ExecSession.Close` and `LogSession.Close` are idempotent.
 
 ### Removed
 
 - Azure Pipelines workflow (`azure-pipelines.yml`).
 - Deprecated `IoFogClient` / `V3APIError` aliases and legacy four-argument `NewIoFogClient` constructor.
+- **`pkg/client`:** microservice exec REST attach/detach methods (`AttachExecMicroservice`, `DetachExecMicroservice`, system variants).
 
 ### Migration
 
@@ -60,6 +65,10 @@ apps.DeployApplication(ctrl, app, name, apps.WithAPIVersion("datasance.com/v3"))
 ```
 
 The Datasance git mirror (`github.com/Datasance/iofog-go-sdk`) ships the same commit SHA as `eclipse-iofog/iofog-go-sdk`; only the **module import path** changes.
+
+Remote log tailing: replace local WebSocket URL/auth assembly with `DialMicroserviceLogs`, `DialSystemMicroserviceLogs`, or `DialFogLogs` (see `pkg/client/README.md`).
+
+Microservice exec: replace `AttachExecMicroservice` / detach REST calls with `DialMicroserviceExec` or `DialSystemMicroserviceExec`; close the session locally instead of REST detach.
 
 ## [v3.0.0-beta1] - 13 Auguest 2021
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
+	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.1
@@ -44,6 +45,7 @@ require (
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
+github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -41,3 +41,67 @@ println(resp.Status)
 ## HTTPS / TLS
 
 Optional `Options.TLSConfig` for HTTPS Controller endpoints. If omitted, the SDK skips certificate verification (self-signed friendly). CLI tools should set this from their trust store; use `InsecureSkipVerify: true` only in explicit insecure mode.
+
+## Microservice exec (WebSocket)
+
+Interactive exec is WebSocket-first. Dial directly — no REST attach step:
+
+```go
+session, err := clt.DialMicroserviceExecWithOptions(microserviceUUID, &client.DialExecOptions{
+	OnStatusLine: func(line string) {
+		fmt.Fprintln(os.Stdout, line)
+	},
+})
+if err != nil {
+	return err
+}
+defer session.Close()
+
+for {
+	frame, err := session.Read()
+	if err != nil {
+		return err
+	}
+	if frame.Type == client.ExecMessageStdout {
+		os.Stdout.Write(frame.Data)
+	}
+}
+```
+
+`OnStatusLine` receives STDERR status lines emitted while waiting for the agent (for example `Waiting for agent connection...`). `ExecSession.Close()` is idempotent.
+
+System microservices use `DialSystemMicroserviceExec` / `DialSystemMicroserviceExecWithOptions`.
+
+Fog node debug still provisions a debug microservice via `AttachExecToAgent`, then uses `DialSystemMicroserviceExec` on the debug microservice UUID.
+
+## Log streaming (WebSocket)
+
+Remote log tailing uses WebSocket sessions with optional query parameters:
+
+```go
+session, err := clt.DialMicroserviceLogs(microserviceUUID, &client.LogTailOptions{
+	Tail:   100,
+	Follow: true,
+})
+if err != nil {
+	return err
+}
+defer session.Close()
+
+for {
+	frame, err := session.Read()
+	if err != nil {
+		return err
+	}
+	switch frame.Type {
+	case client.LogMessageLine:
+		os.Stdout.Write(frame.Data)
+	case client.LogMessageStop:
+		return nil
+	case client.LogMessageError:
+		return fmt.Errorf("%s", frame.Data)
+	}
+}
+```
+
+Use `DialSystemMicroserviceLogs` for system microservices and `DialFogLogs` for Agent (fog node) logs.

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -127,3 +127,23 @@ func (err *NotSupportedError) Error() string {
 // Controller endpoints. The Controller no longer exposes /api/v3/routes or
 // /api/v3/microservices/:uuid/routes; use NATS for messaging instead.
 var ErrRoutesNotSupported = errors.New("routes API is no longer supported by the Controller; use NATS for messaging")
+
+// Exec WebSocket close errors (Controller Plan 17).
+var (
+	ErrExecSessionQuotaExceeded = errors.New("maximum concurrent exec sessions exceeded")
+	ErrExecAgentTimeout         = errors.New("timeout waiting for agent connection")
+	ErrMicroserviceNotRunning   = errors.New("microservice is not running")
+	ErrExecRouterUnavailable    = errors.New("exec router unavailable")
+)
+
+// Log WebSocket close errors.
+var (
+	ErrLogSessionUnavailable      = errors.New("no available log session")
+	ErrLogAuthenticationFailed    = errors.New("log stream authentication failed")
+	ErrAgentNotRunning            = errors.New("agent is not running")
+	ErrLogInsufficientPermissions = errors.New("insufficient permissions for log stream")
+	ErrLogPolicyViolation         = errors.New("log stream policy violation")
+	ErrLogConnectionLost          = errors.New("log stream connection lost")
+	ErrLogMessageTooLarge         = errors.New("log stream message too large")
+	ErrLogServerError             = errors.New("log stream server error")
+)

--- a/pkg/client/exec.go
+++ b/pkg/client/exec.go
@@ -1,0 +1,282 @@
+package client
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+)
+
+const defaultExecHandshakeTimeout = 45 * time.Second
+
+// ExecSessionInfo is parsed from the ACTIVATION frame after a successful exec WebSocket upgrade.
+type ExecSessionInfo struct {
+	SessionID        string `json:"sessionId"`
+	MicroserviceUUID string `json:"microserviceUuid"`
+}
+
+// DialExecOptions configures exec WebSocket dial behavior.
+type DialExecOptions struct {
+	// WaitForAgentReady blocks until STDERR indicates the agent is connected.
+	// Defaults to true when nil.
+	WaitForAgentReady *bool
+	// OnStatusLine is invoked for each STDERR status line emitted while waiting
+	// for the agent (for example "Waiting for agent connection...").
+	OnStatusLine func(string)
+}
+
+// ExecSession is an interactive exec WebSocket session to a microservice container.
+type ExecSession struct {
+	SessionID        string
+	MicroserviceUUID string
+	conn             *ws.Conn
+	closeOnce        sync.Once
+	closeErr         error
+}
+
+// DialMicroserviceExec opens a WebSocket exec session to an application microservice.
+func (clt *Client) DialMicroserviceExec(microserviceUUID string) (*ExecSession, error) {
+	return clt.dialExec(microserviceUUID, fmt.Sprintf("/microservices/exec/%s", microserviceUUID), nil)
+}
+
+// DialSystemMicroserviceExec opens a WebSocket exec session to a system microservice.
+func (clt *Client) DialSystemMicroserviceExec(microserviceUUID string) (*ExecSession, error) {
+	return clt.dialExec(microserviceUUID, fmt.Sprintf("/microservices/system/exec/%s", microserviceUUID), nil)
+}
+
+// DialMicroserviceExecWithOptions opens a WebSocket exec session with dial options.
+func (clt *Client) DialMicroserviceExecWithOptions(microserviceUUID string, opts *DialExecOptions) (*ExecSession, error) {
+	return clt.dialExec(microserviceUUID, fmt.Sprintf("/microservices/exec/%s", microserviceUUID), opts)
+}
+
+// DialSystemMicroserviceExecWithOptions opens a system microservice exec session with dial options.
+func (clt *Client) DialSystemMicroserviceExecWithOptions(microserviceUUID string, opts *DialExecOptions) (*ExecSession, error) {
+	return clt.dialExec(microserviceUUID, fmt.Sprintf("/microservices/system/exec/%s", microserviceUUID), opts)
+}
+
+func (clt *Client) dialExec(microserviceUUID, requestPath string, opts *DialExecOptions) (*ExecSession, error) {
+	if !clt.isLoggedIn() {
+		return nil, NewInputError("client is not logged in")
+	}
+	if microserviceUUID == "" {
+		return nil, NewInputError("microservice UUID is required")
+	}
+
+	wsURL, err := clt.execWSURL(requestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := ws.Dialer{
+		HandshakeTimeout: defaultExecHandshakeTimeout,
+		TLSClientConfig:  clt.execDialTLSConfig(),
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+clt.accessToken)
+
+	conn, resp, err := dialer.Dial(wsURL, headers)
+	if err != nil {
+		if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
+			return nil, NewHTTPError(fmt.Sprintf("exec WebSocket upgrade failed with status %d", resp.StatusCode), resp.StatusCode)
+		}
+		return nil, fmt.Errorf("exec WebSocket dial: %w", err)
+	}
+
+	session := &ExecSession{
+		MicroserviceUUID: microserviceUUID,
+		conn:             conn,
+	}
+
+	info, err := session.readActivation()
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	session.SessionID = info.SessionID
+	session.MicroserviceUUID = info.MicroserviceUUID
+
+	waitForAgent := true
+	if opts != nil && opts.WaitForAgentReady != nil {
+		waitForAgent = *opts.WaitForAgentReady
+	}
+	var onStatusLine func(string)
+	if opts != nil {
+		onStatusLine = opts.OnStatusLine
+	}
+	if waitForAgent {
+		if err := session.waitForAgentReady(onStatusLine); err != nil {
+			_ = session.Close()
+			return nil, err
+		}
+	}
+
+	return session, nil
+}
+
+func (clt *Client) execWSURL(requestPath string) (string, error) {
+	u, err := url.Parse(clt.baseURL.String())
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported base URL scheme %q for WebSocket", u.Scheme)
+	}
+	u.Path = path.Join(u.Path, strings.TrimPrefix(requestPath, "/"))
+	return u.String(), nil
+}
+
+func (clt *Client) execDialTLSConfig() *tls.Config {
+	if clt.tlsConfig != nil {
+		return clt.tlsConfig
+	}
+	return defaultTLSConfig()
+}
+
+// Read reads the next exec frame from the Controller.
+func (s *ExecSession) Read() (*ExecFrame, error) {
+	if s.conn == nil {
+		return nil, NewInternalError("exec session is closed")
+	}
+
+	_, data, err := s.conn.ReadMessage()
+	if err != nil {
+		return nil, mapExecCloseError(err)
+	}
+
+	msg, err := decodeExecWSMessage(data)
+	if err != nil {
+		return nil, err
+	}
+	return execFrameFromMessage(msg), nil
+}
+
+// WriteStdin sends stdin data to the remote container.
+func (s *ExecSession) WriteStdin(data []byte) error {
+	return s.writeFrame(ExecMessageStdin, data)
+}
+
+// WriteControl sends a keepalive control frame.
+func (s *ExecSession) WriteControl(data []byte) error {
+	return s.writeFrame(ExecMessageControl, data)
+}
+
+// Close sends a close frame and closes the WebSocket connection.
+// Close is idempotent and ignores benign errors from an already-closed connection.
+func (s *ExecSession) Close() error {
+	s.closeOnce.Do(func() {
+		if s.conn == nil {
+			return
+		}
+		_ = s.writeFrame(ExecMessageClose, nil)
+		err := s.conn.Close()
+		s.conn = nil
+		if isBenignCloseError(err) {
+			return
+		}
+		s.closeErr = err
+	})
+	return s.closeErr
+}
+
+func (s *ExecSession) writeFrame(msgType uint8, data []byte) error {
+	if s.conn == nil {
+		return NewInternalError("exec session is closed")
+	}
+	payload, err := encodeExecWSMessage(&execWSMessage{
+		Type:             msgType,
+		Data:             data,
+		MicroserviceUUID: s.MicroserviceUUID,
+		ExecID:           s.SessionID,
+		SessionID:        s.SessionID,
+		Timestamp:        time.Now().UnixMilli(),
+	})
+	if err != nil {
+		return err
+	}
+	return s.conn.WriteMessage(ws.BinaryMessage, payload)
+}
+
+func (s *ExecSession) readActivation() (ExecSessionInfo, error) {
+	frame, err := s.readRawFrame()
+	if err != nil {
+		return ExecSessionInfo{}, err
+	}
+	return parseExecSessionInfo(frame)
+}
+
+func (s *ExecSession) waitForAgentReady(onStatusLine func(string)) error {
+	for {
+		frame, err := s.readRawFrame()
+		if err != nil {
+			return err
+		}
+		if frame.Type != ExecMessageStderr {
+			continue
+		}
+		line := string(frame.Data)
+		if onStatusLine != nil && line != "" {
+			onStatusLine(line)
+		}
+		if strings.Contains(line, execAgentReadySubstr) {
+			return nil
+		}
+	}
+}
+
+func isBenignCloseError(err error) bool {
+	if err == nil {
+		return true
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "use of closed network connection") ||
+		strings.Contains(errStr, "connection reset by peer") ||
+		strings.Contains(errStr, "broken pipe")
+}
+
+func (s *ExecSession) readRawFrame() (*execWSMessage, error) {
+	if s.conn == nil {
+		return nil, NewInternalError("exec session is closed")
+	}
+
+	_, data, err := s.conn.ReadMessage()
+	if err != nil {
+		return nil, mapExecCloseError(err)
+	}
+	return decodeExecWSMessage(data)
+}
+
+func mapExecCloseError(err error) error {
+	closeErr := &ws.CloseError{}
+	if !errors.As(err, &closeErr) {
+		return err
+	}
+
+	reason := closeErr.Text
+	switch closeErr.Code {
+	case ws.ClosePolicyViolation: // 1008
+		switch {
+		case strings.Contains(reason, "Maximum of 3 concurrent exec sessions"):
+			return fmt.Errorf("%w: %s", ErrExecSessionQuotaExceeded, reason)
+		case strings.Contains(reason, "Timeout waiting for agent connection"):
+			return fmt.Errorf("%w: %s", ErrExecAgentTimeout, reason)
+		case strings.Contains(reason, "not running"), strings.Contains(reason, "Not running"):
+			return fmt.Errorf("%w: %s", ErrMicroserviceNotRunning, reason)
+		}
+	case 1013:
+		return fmt.Errorf("%w: %s", ErrExecRouterUnavailable, reason)
+	}
+	return fmt.Errorf("exec WebSocket closed (code %d): %s", closeErr.Code, reason)
+}

--- a/pkg/client/exec_message.go
+++ b/pkg/client/exec_message.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	json "github.com/json-iterator/go"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Exec message types for Controller WebSocket exec sessions (MessagePack).
+const (
+	ExecMessageStdin      uint8 = 0
+	ExecMessageStdout     uint8 = 1
+	ExecMessageStderr     uint8 = 2
+	ExecMessageControl    uint8 = 3
+	ExecMessageClose      uint8 = 4
+	ExecMessageActivation uint8 = 5
+)
+
+const execAgentReadySubstr = "Agent connected"
+
+type execWSMessage struct {
+	Type             uint8  `msgpack:"type"`
+	Data             []byte `msgpack:"data"`
+	MicroserviceUUID string `msgpack:"microserviceUuid"`
+	ExecID           string `msgpack:"execId"`
+	SessionID        string `msgpack:"sessionId"`
+	Timestamp        int64  `msgpack:"timestamp"`
+}
+
+// ExecFrame is a decoded exec WebSocket frame from the Controller.
+type ExecFrame struct {
+	Type             uint8
+	Data             []byte
+	MicroserviceUUID string
+	SessionID        string
+}
+
+func decodeExecWSMessage(data []byte) (*execWSMessage, error) {
+	var msg execWSMessage
+	if err := msgpack.Unmarshal(data, &msg); err != nil {
+		return nil, fmt.Errorf("decode exec MessagePack frame: %w", err)
+	}
+	return &msg, nil
+}
+
+func encodeExecWSMessage(msg *execWSMessage) ([]byte, error) {
+	return msgpack.Marshal(msg)
+}
+
+func parseExecSessionInfo(msg *execWSMessage) (ExecSessionInfo, error) {
+	if msg.Type != ExecMessageActivation {
+		return ExecSessionInfo{}, fmt.Errorf("expected ACTIVATION frame, got type %d", msg.Type)
+	}
+
+	info := ExecSessionInfo{
+		SessionID:        firstNonEmpty(msg.SessionID, msg.ExecID),
+		MicroserviceUUID: msg.MicroserviceUUID,
+	}
+
+	if len(msg.Data) > 0 {
+		var fromData ExecSessionInfo
+		if err := json.Unmarshal(msg.Data, &fromData); err != nil {
+			return ExecSessionInfo{}, fmt.Errorf("decode ACTIVATION data JSON: %w", err)
+		}
+		if fromData.SessionID != "" {
+			info.SessionID = fromData.SessionID
+		}
+		if fromData.MicroserviceUUID != "" {
+			info.MicroserviceUUID = fromData.MicroserviceUUID
+		}
+	}
+
+	if info.SessionID == "" {
+		return ExecSessionInfo{}, errors.New("ACTIVATION frame missing sessionId")
+	}
+	if info.MicroserviceUUID == "" {
+		return ExecSessionInfo{}, errors.New("ACTIVATION frame missing microserviceUuid")
+	}
+	return info, nil
+}
+
+func execFrameFromMessage(msg *execWSMessage) *ExecFrame {
+	sessionID := firstNonEmpty(msg.SessionID, msg.ExecID)
+	return &ExecFrame{
+		Type:             msg.Type,
+		Data:             append([]byte(nil), msg.Data...),
+		MicroserviceUUID: msg.MicroserviceUUID,
+		SessionID:        sessionID,
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/client/exec_test.go
+++ b/pkg/client/exec_test.go
@@ -1,0 +1,230 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+	json "github.com/json-iterator/go"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestParseExecSessionInfoFromActivation(t *testing.T) {
+	t.Parallel()
+
+	infoJSON, err := json.Marshal(ExecSessionInfo{
+		SessionID:        "session-from-json",
+		MicroserviceUUID: "ms-from-json",
+	})
+	if err != nil {
+		t.Fatalf("marshal activation json: %v", err)
+	}
+
+	msg := &execWSMessage{
+		Type:             ExecMessageActivation,
+		Data:             infoJSON,
+		MicroserviceUUID: "ms-top-level",
+		ExecID:           "session-top-level",
+		SessionID:        "session-top-level",
+		Timestamp:        time.Now().UnixMilli(),
+	}
+
+	info, err := parseExecSessionInfo(msg)
+	if err != nil {
+		t.Fatalf("parseExecSessionInfo: %v", err)
+	}
+	if info.SessionID != "session-from-json" {
+		t.Fatalf("expected sessionId from JSON data, got %q", info.SessionID)
+	}
+	if info.MicroserviceUUID != "ms-from-json" {
+		t.Fatalf("expected microserviceUuid from JSON data, got %q", info.MicroserviceUUID)
+	}
+}
+
+func TestParseExecSessionInfoUsesTopLevelFields(t *testing.T) {
+	t.Parallel()
+
+	msg := &execWSMessage{
+		Type:             ExecMessageActivation,
+		MicroserviceUUID: "ms-uuid",
+		ExecID:           "exec-id",
+	}
+
+	info, err := parseExecSessionInfo(msg)
+	if err != nil {
+		t.Fatalf("parseExecSessionInfo: %v", err)
+	}
+	if info.SessionID != "exec-id" {
+		t.Fatalf("expected exec-id as sessionId, got %q", info.SessionID)
+	}
+	if info.MicroserviceUUID != "ms-uuid" {
+		t.Fatalf("expected ms-uuid, got %q", info.MicroserviceUUID)
+	}
+}
+
+func TestExecWSURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		path     string
+		expected string
+	}{
+		{
+			name:     "http to ws",
+			baseURL:  "http://localhost:51121/api/v3",
+			path:     "/microservices/exec/uuid-1",
+			expected: "ws://localhost:51121/api/v3/microservices/exec/uuid-1",
+		},
+		{
+			name:     "https to wss system exec",
+			baseURL:  "https://controller.example/api/v3",
+			path:     "/microservices/system/exec/uuid-2",
+			expected: "wss://controller.example/api/v3/microservices/system/exec/uuid-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			u, err := url.Parse(tt.baseURL)
+			if err != nil {
+				t.Fatalf("parse base url: %v", err)
+			}
+			clt := &Client{baseURL: u}
+			got, err := clt.execWSURL(strings.TrimPrefix(tt.path, "/"))
+			if err != nil {
+				t.Fatalf("execWSURL: %v", err)
+			}
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestMapExecCloseError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		code   int
+		reason string
+		target error
+	}{
+		{"quota", ws.ClosePolicyViolation, "Maximum of 3 concurrent exec sessions allowed", ErrExecSessionQuotaExceeded},
+		{"agent timeout", ws.ClosePolicyViolation, "Timeout waiting for agent connection", ErrExecAgentTimeout},
+		{"not running", ws.ClosePolicyViolation, "Microservice is not running", ErrMicroserviceNotRunning},
+		{"router unavailable", 1013, "Try again later", ErrExecRouterUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := mapExecCloseError(&ws.CloseError{Code: tt.code, Text: tt.reason})
+			if err == nil {
+				t.Fatal("expected mapped error")
+			}
+			if !strings.Contains(err.Error(), tt.target.Error()) {
+				t.Fatalf("expected error containing %q, got %v", tt.target.Error(), err)
+			}
+		})
+	}
+}
+
+func TestDialMicroserviceExec(t *testing.T) {
+	const (
+		msUUID    = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+		sessionID = "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+	)
+
+	upgrader := ws.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path != "/api/v3/microservices/exec/"+msUUID {
+			http.NotFound(w, r)
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		activation, err := msgpack.Marshal(&execWSMessage{
+			Type:             ExecMessageActivation,
+			MicroserviceUUID: msUUID,
+			ExecID:           sessionID,
+			SessionID:        sessionID,
+			Data: mustJSON(t, ExecSessionInfo{
+				SessionID:        sessionID,
+				MicroserviceUUID: msUUID,
+			}),
+		})
+		if err != nil {
+			return
+		}
+		if err := conn.WriteMessage(ws.BinaryMessage, activation); err != nil {
+			return
+		}
+
+		stderr, err := msgpack.Marshal(&execWSMessage{
+			Type:             ExecMessageStderr,
+			MicroserviceUUID: msUUID,
+			ExecID:           sessionID,
+			SessionID:        sessionID,
+			Data:             []byte("Agent connected. Interactive exec is ready."),
+		})
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(ws.BinaryMessage, stderr)
+		<-time.After(100 * time.Millisecond)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/api/v3")
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	clt := &Client{
+		baseURL:     baseURL,
+		accessToken: "test-token",
+	}
+
+	session, err := clt.DialMicroserviceExec(msUUID)
+	if err != nil {
+		t.Fatalf("DialMicroserviceExec: %v", err)
+	}
+	defer session.Close()
+
+	if session.SessionID != sessionID {
+		t.Fatalf("expected sessionId %q, got %q", sessionID, session.SessionID)
+	}
+	if session.MicroserviceUUID != msUUID {
+		t.Fatalf("expected microserviceUuid %q, got %q", msUUID, session.MicroserviceUUID)
+	}
+
+	if err := session.WriteStdin([]byte("echo hi\n")); err != nil {
+		t.Fatalf("WriteStdin: %v", err)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return data
+}

--- a/pkg/client/log.go
+++ b/pkg/client/log.go
@@ -1,0 +1,188 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+)
+
+const defaultLogHandshakeTimeout = 45 * time.Second
+
+// LogTailOptions configures log WebSocket query parameters.
+type LogTailOptions struct {
+	Tail   int
+	Follow bool
+	Since  string
+	Until  string
+}
+
+// LogSession is a WebSocket log streaming session from the Controller.
+type LogSession struct {
+	SessionID string
+	conn      *ws.Conn
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// DialMicroserviceLogs opens a WebSocket log stream for an application microservice.
+func (clt *Client) DialMicroserviceLogs(microserviceUUID string, opts *LogTailOptions) (*LogSession, error) {
+	return clt.dialLogs(fmt.Sprintf("/microservices/%s/logs", microserviceUUID), opts)
+}
+
+// DialSystemMicroserviceLogs opens a WebSocket log stream for a system microservice.
+func (clt *Client) DialSystemMicroserviceLogs(microserviceUUID string, opts *LogTailOptions) (*LogSession, error) {
+	return clt.dialLogs(fmt.Sprintf("/microservices/system/%s/logs", microserviceUUID), opts)
+}
+
+// DialFogLogs opens a WebSocket log stream for a fog node (Agent).
+func (clt *Client) DialFogLogs(fogUUID string, opts *LogTailOptions) (*LogSession, error) {
+	return clt.dialLogs(fmt.Sprintf("/iofog/%s/logs", fogUUID), opts)
+}
+
+func (clt *Client) dialLogs(requestPath string, opts *LogTailOptions) (*LogSession, error) {
+	if !clt.isLoggedIn() {
+		return nil, NewInputError("client is not logged in")
+	}
+
+	wsURL, err := clt.logWSURL(requestPath, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := ws.Dialer{
+		HandshakeTimeout: defaultLogHandshakeTimeout,
+		TLSClientConfig:  clt.execDialTLSConfig(),
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+clt.accessToken)
+
+	conn, resp, err := dialer.Dial(wsURL, headers)
+	if err != nil {
+		if resp != nil && resp.StatusCode != http.StatusSwitchingProtocols {
+			return nil, NewHTTPError(fmt.Sprintf("log WebSocket upgrade failed with status %d", resp.StatusCode), resp.StatusCode)
+		}
+		return nil, fmt.Errorf("log WebSocket dial: %w", err)
+	}
+
+	return &LogSession{conn: conn}, nil
+}
+
+func (clt *Client) logWSURL(requestPath string, opts *LogTailOptions) (string, error) {
+	u, err := url.Parse(clt.baseURL.String())
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported base URL scheme %q for WebSocket", u.Scheme)
+	}
+	u.Path = path.Join(u.Path, strings.TrimPrefix(requestPath, "/"))
+	if query := logTailQuery(opts); query != "" {
+		u.RawQuery = query
+	}
+	return u.String(), nil
+}
+
+func logTailQuery(opts *LogTailOptions) string {
+	values := url.Values{}
+	tail := 100
+	follow := true
+	if opts != nil {
+		if opts.Tail > 0 {
+			tail = opts.Tail
+		}
+		follow = opts.Follow
+		if opts.Since != "" {
+			values.Set("since", opts.Since)
+		}
+		if opts.Until != "" {
+			values.Set("until", opts.Until)
+		}
+	}
+	values.Set("tail", fmt.Sprintf("%d", tail))
+	values.Set("follow", fmt.Sprintf("%t", follow))
+	return values.Encode()
+}
+
+// Read reads the next log frame from the Controller.
+func (s *LogSession) Read() (*LogFrame, error) {
+	if s.conn == nil {
+		return nil, NewInternalError("log session is closed")
+	}
+
+	_, data, err := s.conn.ReadMessage()
+	if err != nil {
+		return nil, mapLogCloseError(err)
+	}
+
+	msg, err := decodeLogWSMessage(data)
+	if err != nil {
+		return nil, err
+	}
+
+	frame := logFrameFromMessage(msg)
+	if frame.SessionID != "" {
+		s.SessionID = frame.SessionID
+	}
+	return frame, nil
+}
+
+// Close closes the log WebSocket connection.
+func (s *LogSession) Close() error {
+	s.closeOnce.Do(func() {
+		if s.conn == nil {
+			return
+		}
+		err := s.conn.Close()
+		s.conn = nil
+		if isBenignCloseError(err) {
+			return
+		}
+		s.closeErr = err
+	})
+	return s.closeErr
+}
+
+func mapLogCloseError(err error) error {
+	closeErr := &ws.CloseError{}
+	if !errors.As(err, &closeErr) {
+		return err
+	}
+
+	reason := closeErr.Text
+	switch closeErr.Code {
+	case ws.ClosePolicyViolation: // 1008
+		switch {
+		case strings.Contains(reason, "No available log session"):
+			return fmt.Errorf("%w: %s", ErrLogSessionUnavailable, reason)
+		case strings.Contains(reason, "Authentication failed"):
+			return fmt.Errorf("%w: %s", ErrLogAuthenticationFailed, reason)
+		case strings.Contains(reason, "Agent is not running"), strings.Contains(reason, "not running"):
+			return fmt.Errorf("%w: %s", ErrAgentNotRunning, reason)
+		case strings.Contains(reason, "Microservice is not running"), strings.Contains(reason, "Not running"):
+			return fmt.Errorf("%w: %s", ErrMicroserviceNotRunning, reason)
+		case strings.Contains(reason, "Insufficient permissions"):
+			return fmt.Errorf("%w: %s", ErrLogInsufficientPermissions, reason)
+		}
+		return fmt.Errorf("%w: %s", ErrLogPolicyViolation, reason)
+	case ws.CloseAbnormalClosure: // 1006
+		return fmt.Errorf("%w: %s", ErrLogConnectionLost, reason)
+	case ws.CloseMessageTooBig: // 1009
+		return fmt.Errorf("%w: %s", ErrLogMessageTooLarge, reason)
+	case ws.CloseInternalServerErr: // 1011
+		return fmt.Errorf("%w: %s", ErrLogServerError, reason)
+	}
+	return fmt.Errorf("log WebSocket closed (code %d): %s", closeErr.Code, reason)
+}

--- a/pkg/client/log_message.go
+++ b/pkg/client/log_message.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Log message types for Controller WebSocket log sessions (MessagePack).
+const (
+	LogMessageLine  uint8 = 6
+	LogMessageStart uint8 = 7
+	LogMessageStop  uint8 = 8
+	LogMessageError uint8 = 9
+)
+
+type logWSMessage struct {
+	Type             uint8  `msgpack:"type"`
+	Data             []byte `msgpack:"data"`
+	MicroserviceUUID string `msgpack:"microserviceUuid"`
+	ExecID           string `msgpack:"execId"`
+	SessionID        string `msgpack:"sessionId"`
+	Timestamp        int64  `msgpack:"timestamp"`
+}
+
+// LogFrame is a decoded log WebSocket frame from the Controller.
+type LogFrame struct {
+	Type      uint8
+	Data      []byte
+	SessionID string
+}
+
+func decodeLogWSMessage(data []byte) (*logWSMessage, error) {
+	var msg logWSMessage
+	if err := msgpack.Unmarshal(data, &msg); err != nil {
+		return nil, fmt.Errorf("decode log MessagePack frame: %w", err)
+	}
+	return &msg, nil
+}
+
+func logFrameFromMessage(msg *logWSMessage) *LogFrame {
+	return &LogFrame{
+		Type:      msg.Type,
+		Data:      append([]byte(nil), msg.Data...),
+		SessionID: firstNonEmpty(msg.SessionID, msg.ExecID),
+	}
+}

--- a/pkg/client/log_test.go
+++ b/pkg/client/log_test.go
@@ -1,0 +1,217 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	ws "github.com/gorilla/websocket"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestLogTailQuery(t *testing.T) {
+	t.Parallel()
+
+	got := logTailQuery(&LogTailOptions{
+		Tail:   50,
+		Follow: false,
+		Since:  "2024-01-01T00:00:00Z",
+	})
+	if !strings.Contains(got, "tail=50") {
+		t.Fatalf("expected tail=50 in %q", got)
+	}
+	if !strings.Contains(got, "follow=false") {
+		t.Fatalf("expected follow=false in %q", got)
+	}
+	if !strings.Contains(got, "since=2024-01-01T00%3A00%3A00Z") {
+		t.Fatalf("expected since query param in %q", got)
+	}
+}
+
+func TestDialMicroserviceLogs(t *testing.T) {
+	const msUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+	upgrader := ws.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path != "/api/v3/microservices/"+msUUID+"/logs" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("tail") != "10" {
+			http.Error(w, "bad tail", http.StatusBadRequest)
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		start, err := msgpack.Marshal(&logWSMessage{
+			Type:      LogMessageStart,
+			ExecID:    "session-1",
+			SessionID: "session-1",
+		})
+		if err != nil {
+			return
+		}
+		if err := conn.WriteMessage(ws.BinaryMessage, start); err != nil {
+			return
+		}
+
+		line, err := msgpack.Marshal(&logWSMessage{
+			Type: LogMessageLine,
+			Data: []byte("hello\n"),
+		})
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(ws.BinaryMessage, line)
+
+		stop, err := msgpack.Marshal(&logWSMessage{Type: LogMessageStop})
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(ws.BinaryMessage, stop)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/api/v3")
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	clt := &Client{
+		baseURL:     baseURL,
+		accessToken: "test-token",
+	}
+
+	session, err := clt.DialMicroserviceLogs(msUUID, &LogTailOptions{Tail: 10, Follow: false})
+	if err != nil {
+		t.Fatalf("DialMicroserviceLogs: %v", err)
+	}
+	defer session.Close()
+
+	frame, err := session.Read()
+	if err != nil {
+		t.Fatalf("Read start: %v", err)
+	}
+	if frame.Type != LogMessageStart {
+		t.Fatalf("expected LOG_START, got type %d", frame.Type)
+	}
+
+	frame, err = session.Read()
+	if err != nil {
+		t.Fatalf("Read line: %v", err)
+	}
+	if frame.Type != LogMessageLine || string(frame.Data) != "hello\n" {
+		t.Fatalf("unexpected log line frame: %+v", frame)
+	}
+
+	frame, err = session.Read()
+	if err != nil {
+		t.Fatalf("Read stop: %v", err)
+	}
+	if frame.Type != LogMessageStop {
+		t.Fatalf("expected LOG_STOP, got type %d", frame.Type)
+	}
+}
+
+func TestDialExecOnStatusLine(t *testing.T) {
+	const (
+		msUUID    = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+		sessionID = "f9e8d7c6-b5a4-3210-fedc-ba9876543210"
+	)
+
+	upgrader := ws.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		activation, _ := msgpack.Marshal(&execWSMessage{
+			Type:             ExecMessageActivation,
+			MicroserviceUUID: msUUID,
+			SessionID:        sessionID,
+			Data: mustJSON(t, ExecSessionInfo{
+				SessionID:        sessionID,
+				MicroserviceUUID: msUUID,
+			}),
+		})
+		_ = conn.WriteMessage(ws.BinaryMessage, activation)
+
+		waiting, _ := msgpack.Marshal(&execWSMessage{
+			Type: ExecMessageStderr,
+			Data: []byte("Waiting for agent connection..."),
+		})
+		_ = conn.WriteMessage(ws.BinaryMessage, waiting)
+
+		ready, _ := msgpack.Marshal(&execWSMessage{
+			Type: ExecMessageStderr,
+			Data: []byte("Agent connected. Interactive exec is ready."),
+		})
+		_ = conn.WriteMessage(ws.BinaryMessage, ready)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/api/v3")
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+
+	clt := &Client{
+		baseURL:     baseURL,
+		accessToken: "test-token",
+	}
+
+	var lines []string
+	session, err := clt.DialMicroserviceExecWithOptions(msUUID, &DialExecOptions{
+		OnStatusLine: func(line string) {
+			lines = append(lines, line)
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialMicroserviceExecWithOptions: %v", err)
+	}
+	defer session.Close()
+
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 status lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "Waiting for agent connection..." {
+		t.Fatalf("unexpected first status line: %q", lines[0])
+	}
+}
+
+func TestExecSessionCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	session := &ExecSession{}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close on nil conn: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestLogSessionCloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	session := &LogSession{}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close on nil conn: %v", err)
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/pkg/client/resources.go
+++ b/pkg/client/resources.go
@@ -505,26 +505,6 @@ func (clt *Client) RenewCertificate(name string) error {
 	return err
 }
 
-func (clt *Client) AttachExecMicroservice(request *AttachExecMicroserviceRequest) error {
-	_, err := clt.doRequest("POST", fmt.Sprintf("/microservices/%s/exec", request.UUID), request)
-	return err
-}
-
-func (clt *Client) DetachExecMicroservice(request *DetachExecMicroserviceRequest) error {
-	_, err := clt.doRequest("DELETE", fmt.Sprintf("/microservices/%s/exec", request.UUID), request)
-	return err
-}
-
-func (clt *Client) AttachExecSystemMicroservice(request *AttachExecMicroserviceRequest) error {
-	_, err := clt.doRequest("POST", fmt.Sprintf("/microservices/system/%s/exec", request.UUID), request)
-	return err
-}
-
-func (clt *Client) DetachExecSystemMicroservice(request *DetachExecMicroserviceRequest) error {
-	_, err := clt.doRequest("DELETE", fmt.Sprintf("/microservices/system/%s/exec", request.UUID), request)
-	return err
-}
-
 func (clt *Client) AttachExecToAgent(request *AttachExecToAgentRequest) error {
 	_, err := clt.doRequest("POST", fmt.Sprintf("/iofog/%s/exec", request.UUID), request)
 	return err

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -1042,14 +1042,6 @@ type CAListResponse struct {
 	CAs []CAInfo `json:"cas"`
 }
 
-type AttachExecMicroserviceRequest struct {
-	UUID string `json:"uuid"`
-}
-
-type DetachExecMicroserviceRequest struct {
-	UUID string `json:"uuid"`
-}
-
 type AttachExecToAgentRequest struct {
 	UUID  string  `json:"uuid"`
 	Image *string `json:"image,omitempty"`


### PR DESCRIPTION
Replace microservice exec REST attach/detach with direct WS dial APIs and add log streaming dial helpers for potctl/iofogctl consumers.