### PR TITLE
feat(client): add auth groups API; fix apps deploy NotFound handling

### DIFF
--- a/pkg/apps/applications.go
+++ b/pkg/apps/applications.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -35,17 +34,12 @@ func (exe *applicationExecutor) execute() (err error) {
 		return err
 	}
 
-	// Try application API
-	// Look for exisiting application
+	// Look up existing application; NotFound means create on deploy.
 	exe.applicationInfo, err = exe.client.GetApplicationByName(exe.name)
-
-	// If not notfound error, return error
-	notFoundError := &client.NotFoundError{}
-	if errors.As(err, &notFoundError) {
+	if err = lookupErrorAllowNotFound(err); err != nil {
 		return err
 	}
 
-	// Deploy application
 	return exe.deploy()
 }
 

--- a/pkg/apps/lookup.go
+++ b/pkg/apps/lookup.go
@@ -1,0 +1,20 @@
+package apps
+
+import (
+	"errors"
+
+	"github.com/eclipse-iofog/iofog-go-sdk/v3/pkg/client"
+)
+
+// lookupErrorAllowNotFound returns nil when the resource is absent (NotFound).
+// Any other lookup error is returned as-is.
+func lookupErrorAllowNotFound(err error) error {
+	if err == nil {
+		return nil
+	}
+	var notFoundError *client.NotFoundError
+	if errors.As(err, &notFoundError) {
+		return nil
+	}
+	return err
+}

--- a/pkg/apps/lookup_test.go
+++ b/pkg/apps/lookup_test.go
@@ -1,0 +1,28 @@
+package apps
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eclipse-iofog/iofog-go-sdk/v3/pkg/client"
+)
+
+func TestLookupErrorAllowNotFound(t *testing.T) {
+	t.Parallel()
+
+	if err := lookupErrorAllowNotFound(nil); err != nil {
+		t.Fatalf("expected nil for nil input, got %v", err)
+	}
+
+	notFound := client.NewNotFoundError("missing")
+	if err := lookupErrorAllowNotFound(notFound); err != nil {
+		t.Fatalf("expected nil for NotFound, got %v", err)
+	}
+
+	other := client.NewHTTPError("server error", 500)
+	if err := lookupErrorAllowNotFound(other); err == nil {
+		t.Fatal("expected error for non-NotFound lookup failure")
+	} else if !errors.Is(err, other) {
+		t.Fatalf("expected original error, got %v", err)
+	}
+}

--- a/pkg/apps/templates.go
+++ b/pkg/apps/templates.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"bytes"
-	"errors"
 	"net/url"
 
 	"github.com/eclipse-iofog/iofog-go-sdk/v3/pkg/client"
@@ -63,9 +62,7 @@ func (exe *applicationTemplateExecutor) deploy() error {
 		return err
 	}
 	existingAppTemplate, err := exe.client.GetApplicationTemplate(exe.name)
-	// If not notfound error, return error
-	notFoundError := &client.NotFoundError{}
-	if errors.As(err, &notFoundError) {
+	if err = lookupErrorAllowNotFound(err); err != nil {
 		return err
 	}
 	if existingAppTemplate == nil {

--- a/pkg/client/auth_groups.go
+++ b/pkg/client/auth_groups.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+func authGroupPath(name string) string {
+	return fmt.Sprintf("/groups/%s", url.PathEscape(name))
+}
+
+// ListAuthGroups retrieves all embedded auth groups using Controller REST API.
+func (clt *Client) ListAuthGroups() ([]AuthGroupResponse, error) {
+	body, err := clt.doRequest("GET", "/groups", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var groups []AuthGroupResponse
+	if err = json.Unmarshal(body, &groups); err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+// CreateAuthGroup creates a custom embedded auth group using Controller REST API.
+func (clt *Client) CreateAuthGroup(request AuthGroupCreateRequest) (AuthGroupResponse, error) {
+	var response AuthGroupResponse
+	body, err := clt.doRequest("POST", "/groups", request)
+	if err != nil {
+		return response, err
+	}
+
+	if err = json.Unmarshal(body, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetAuthGroup retrieves an embedded auth group by name using Controller REST API.
+func (clt *Client) GetAuthGroup(name string) (AuthGroupResponse, error) {
+	var response AuthGroupResponse
+	body, err := clt.doRequest("GET", authGroupPath(name), nil)
+	if err != nil {
+		return response, err
+	}
+
+	if err = json.Unmarshal(body, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UpdateAuthGroup updates an embedded auth group using Controller REST API.
+// After a successful rename, use response.Name as the canonical group name.
+func (clt *Client) UpdateAuthGroup(name string, request AuthGroupUpdateRequest) (AuthGroupResponse, error) {
+	var response AuthGroupResponse
+	body, err := clt.doRequest("PATCH", authGroupPath(name), request)
+	if err != nil {
+		return response, err
+	}
+
+	if err = json.Unmarshal(body, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DeleteAuthGroup deletes a custom embedded auth group using Controller REST API.
+func (clt *Client) DeleteAuthGroup(name string) error {
+	_, err := clt.doRequest("DELETE", authGroupPath(name), nil)
+	return err
+}

--- a/pkg/client/auth_groups_test.go
+++ b/pkg/client/auth_groups_test.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAuthGroupsCRUD(t *testing.T) {
+	var stored AuthGroupResponse
+
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Fatalf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/groups":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode([]AuthGroupResponse{stored})
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/groups":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			var req AuthGroupCreateRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("unmarshal create: %v", err)
+			}
+			mfaRequired := req.MfaRequired != nil && *req.MfaRequired
+			stored = AuthGroupResponse{
+				ID:          10,
+				Name:        req.Name,
+				IsSystem:    false,
+				MfaRequired: mfaRequired,
+				CreatedAt:   "2026-01-01T00:00:00.000Z",
+				UpdatedAt:   "2026-01-01T00:00:00.000Z",
+			}
+			w.WriteHeader(http.StatusCreated)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(stored)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v3/groups/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(stored)
+		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/api/v3/groups/"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			var req AuthGroupUpdateRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("unmarshal update: %v", err)
+			}
+			if req.Name != nil {
+				stored.Name = *req.Name
+			}
+			if req.MfaRequired != nil {
+				stored.MfaRequired = *req.MfaRequired
+			}
+			stored.UpdatedAt = "2026-01-02T00:00:00.000Z"
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(stored)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v3/groups/"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	mfaRequired := true
+	created, err := clt.CreateAuthGroup(AuthGroupCreateRequest{
+		Name:        "secops",
+		MfaRequired: &mfaRequired,
+	})
+	if err != nil {
+		t.Fatalf("CreateAuthGroup: %v", err)
+	}
+	if created.Name != "secops" || !created.MfaRequired {
+		t.Fatalf("created = %+v", created)
+	}
+
+	groups, err := clt.ListAuthGroups()
+	if err != nil {
+		t.Fatalf("ListAuthGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Name != "secops" {
+		t.Fatalf("groups = %+v", groups)
+	}
+
+	got, err := clt.GetAuthGroup("secops")
+	if err != nil {
+		t.Fatalf("GetAuthGroup: %v", err)
+	}
+	if got.Name != "secops" {
+		t.Fatalf("got = %+v", got)
+	}
+
+	newName := "platform-ops"
+	mfaOff := false
+	updated, err := clt.UpdateAuthGroup("secops", AuthGroupUpdateRequest{
+		Name:        &newName,
+		MfaRequired: &mfaOff,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAuthGroup: %v", err)
+	}
+	if updated.Name != "platform-ops" || updated.MfaRequired {
+		t.Fatalf("updated = %+v", updated)
+	}
+
+	if err := clt.DeleteAuthGroup("platform-ops"); err != nil {
+		t.Fatalf("DeleteAuthGroup: %v", err)
+	}
+}
+
+func TestGetAuthGroupPathEscape(t *testing.T) {
+	var requestedPath string
+
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthGroupResponse{Name: "platform ops"})
+	})
+
+	if _, err := clt.GetAuthGroup("platform ops"); err != nil {
+		t.Fatalf("GetAuthGroup: %v", err)
+	}
+	if requestedPath != "/api/v3/groups/platform%20ops" {
+		t.Fatalf("path = %q, want %q", requestedPath, "/api/v3/groups/platform%20ops")
+	}
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -490,6 +490,25 @@ type AuthUserResetTokenResponse struct {
 	ExpiresIn  int    `json:"expiresIn"`
 }
 
+type AuthGroupCreateRequest struct {
+	Name        string `json:"name"`
+	MfaRequired *bool  `json:"mfaRequired,omitempty"`
+}
+
+type AuthGroupUpdateRequest struct {
+	Name        *string `json:"name,omitempty"`
+	MfaRequired *bool   `json:"mfaRequired,omitempty"`
+}
+
+type AuthGroupResponse struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	IsSystem    bool   `json:"isSystem"`
+	MfaRequired bool   `json:"mfaRequired"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
 type ControllerVersions struct {
 	Controller string `json:"controller"`
 	EcnViewer  string `json:"ecnViewer"`


### PR DESCRIPTION
Add embedded auth group client methods for /api/v3/groups and correct inverted NotFound logic in apps deploy executors via a shared helper.