### PR TITLE
feat(client): add optional semver on node upgrade/rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`pkg/client` — node version commands:** optional target `semver` on upgrade/rollback via `SetNodeVersionCommand`, `UpgradeNode`, `RollbackNode`, and extended `UpgradeAgent` / `RollbackAgent`. Matches Controller v3.8 `POST /iofog/{uuid}/version/{versionCommand}` body.
+
 ## [v3.8.1] - 10 July 2026
 
 ### Fixed

--- a/pkg/client/agents.go
+++ b/pkg/client/agents.go
@@ -154,28 +154,49 @@ func generateListAgentURL(request ListAgentsRequest) string {
 	return url
 }
 
-func (clt *Client) UpgradeAgent(name string) error {
-	agent, err := clt.GetAgentByName(name)
-	if err != nil {
-		return err
+// SetNodeVersionCommand sets an upgrade or rollback version command on a Controller-managed fog node.
+// versionCommand must be "upgrade" or "rollback". Pass req nil or req.Semver nil to omit a target semver.
+func (clt *Client) SetNodeVersionCommand(uuid, versionCommand string, req *SetNodeVersionCommandRequest) error {
+	var semver *string
+	if req != nil {
+		semver = req.Semver
 	}
-
-	if _, err := clt.doRequest("POST", fmt.Sprintf("/iofog/%s/version/upgrade", agent.UUID), nil); err != nil {
-		return err
-	}
-
-	return nil
+	return clt.setNodeVersionCommand(uuid, versionCommand, semver)
 }
 
-func (clt *Client) RollbackAgent(name string) error {
+// UpgradeNode requests an upgrade for a fog node by UUID. Pass semver nil to use Controller default behavior.
+func (clt *Client) UpgradeNode(uuid string, semver *string) error {
+	return clt.setNodeVersionCommand(uuid, "upgrade", semver)
+}
+
+// RollbackNode requests a rollback for a fog node by UUID. Pass semver nil to use Controller default behavior.
+func (clt *Client) RollbackNode(uuid string, semver *string) error {
+	return clt.setNodeVersionCommand(uuid, "rollback", semver)
+}
+
+// UpgradeAgent requests an upgrade for a fog node looked up by name. Pass semver nil for default behavior.
+func (clt *Client) UpgradeAgent(name string, semver *string) error {
 	agent, err := clt.GetAgentByName(name)
 	if err != nil {
 		return err
 	}
+	return clt.setNodeVersionCommand(agent.UUID, "upgrade", semver)
+}
 
-	if _, err := clt.doRequest("POST", fmt.Sprintf("/iofog/%s/version/rollback", agent.UUID), nil); err != nil {
+// RollbackAgent requests a rollback for a fog node looked up by name. Pass semver nil for default behavior.
+func (clt *Client) RollbackAgent(name string, semver *string) error {
+	agent, err := clt.GetAgentByName(name)
+	if err != nil {
 		return err
 	}
+	return clt.setNodeVersionCommand(agent.UUID, "rollback", semver)
+}
 
-	return nil
+func (clt *Client) setNodeVersionCommand(uuid, command string, semver *string) error {
+	var body any
+	if semver != nil && *semver != "" {
+		body = SetNodeVersionCommandRequest{Semver: semver}
+	}
+	_, err := clt.doRequest("POST", fmt.Sprintf("/iofog/%s/version/%s", uuid, command), body)
+	return err
 }

--- a/pkg/client/agents_test.go
+++ b/pkg/client/agents_test.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+const testAgentUUID = "fdb5fca7-4cb1-4e4b-919a-43b116bc1f9d"
+
+func readRequestBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	if r.Body == nil {
+		return ""
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(body)
+}
+
+func assertVersionCommandRequest(t *testing.T, r *http.Request, command, wantBody string) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Fatalf("method = %q, want POST", r.Method)
+	}
+	wantPath := "/api/v3/iofog/" + testAgentUUID + "/version/" + command
+	if r.URL.Path != wantPath {
+		t.Fatalf("path = %q, want %q", r.URL.Path, wantPath)
+	}
+	if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+		t.Fatalf("authorization = %q", auth)
+	}
+	if got := readRequestBody(t, r); got != wantBody {
+		t.Fatalf("body = %q, want %q", got, wantBody)
+	}
+}
+
+func TestUpgradeNodeWithoutSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertVersionCommandRequest(t, r, "upgrade", "")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := clt.UpgradeNode(testAgentUUID, nil); err != nil {
+		t.Fatalf("UpgradeNode: %v", err)
+	}
+}
+
+func TestUpgradeNodeWithSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertVersionCommandRequest(t, r, "upgrade", `{"semver":"3.2.0"}`)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	semver := "3.2.0"
+	if err := clt.UpgradeNode(testAgentUUID, &semver); err != nil {
+		t.Fatalf("UpgradeNode: %v", err)
+	}
+}
+
+func TestRollbackNodeWithSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertVersionCommandRequest(t, r, "rollback", `{"semver":"3.1.0"}`)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	semver := "3.1.0"
+	if err := clt.RollbackNode(testAgentUUID, &semver); err != nil {
+		t.Fatalf("RollbackNode: %v", err)
+	}
+}
+
+func TestSetNodeVersionCommandWithoutSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertVersionCommandRequest(t, r, "upgrade", "")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := clt.SetNodeVersionCommand(testAgentUUID, "upgrade", nil); err != nil {
+		t.Fatalf("SetNodeVersionCommand: %v", err)
+	}
+}
+
+func TestSetNodeVersionCommandWithSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertVersionCommandRequest(t, r, "rollback", `{"semver":"v1.0.0-beta.2"}`)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	semver := "v1.0.0-beta.2"
+	if err := clt.SetNodeVersionCommand(testAgentUUID, "rollback", &SetNodeVersionCommandRequest{
+		Semver: &semver,
+	}); err != nil {
+		t.Fatalf("SetNodeVersionCommand: %v", err)
+	}
+}
+
+func TestSetNodeVersionCommandInvalidSemver(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"message": "ValidationError",
+		})
+	})
+
+	semver := "not-a-semver"
+	err := clt.SetNodeVersionCommand(testAgentUUID, "upgrade", &SetNodeVersionCommandRequest{
+		Semver: &semver,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid semver")
+	}
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want %d", httpErr.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpgradeNodeNotReady(t *testing.T) {
+	clt := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"INVALID_VERSION_COMMAND_UPGRADE"}`))
+	})
+
+	err := clt.UpgradeNode(testAgentUUID, nil)
+	if err == nil {
+		t.Fatal("expected error when node is not ready to upgrade")
+	}
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want %d", httpErr.Code, http.StatusBadRequest)
+	}
+}

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -761,6 +761,12 @@ type AgentListFilter struct {
 	Condition string `json:"condition"`
 }
 
+// SetNodeVersionCommandRequest is the optional body for POST /iofog/{uuid}/version/{versionCommand}.
+// Omit Semver (nil) to use Controller default upgrade/rollback behavior.
+type SetNodeVersionCommandRequest struct {
+	Semver *string `json:"semver,omitempty"`
+}
+
 type Router struct {
 	RouterConfig
 	Host string `json:"host"`


### PR DESCRIPTION
Expose SetNodeVersionCommand, UpgradeNode, and RollbackNode for Controller v3.8 version commands, and extend UpgradeAgent/RollbackAgent with an optional target semver while keeping default behavior when omitted.